### PR TITLE
get attr by fetching from __dict__

### DIFF
--- a/rqalpha/mod/__init__.py
+++ b/rqalpha/mod/__init__.py
@@ -36,7 +36,7 @@ class ModHandler(object):
 
         for mod_name in config.mod.__dict__:
             mod_config = getattr(config.mod, mod_name)
-            if not mod_config.enabled:
+            if not mod_config.__dict__.get('enabled'):
                 continue
             self._mod_list.append((mod_name, mod_config))
 


### PR DESCRIPTION
原来的方式  用run_file的方式 取不到enabled

报错 

mod/__init__.py  43:
RqAttrDict object has no attribute 'enabled'