### PR TITLE
fix command generate_config

### DIFF
--- a/rqalpha/__main__.py
+++ b/rqalpha/__main__.py
@@ -166,7 +166,7 @@ def generate_config(directory):
     """
     Generate default config file
     """
-    default_config = os.path.join(os.path.dirname(os.path.realpath(__file__)), "default_config.yml")
+    default_config = os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.yml")
     target_config_path = os.path.abspath(os.path.join(directory, 'config.yml'))
     shutil.copy(default_config, target_config_path)
     six.print_("Config file has been generated in", target_config_path)


### PR DESCRIPTION
The default config in repo has been renamed to config.yml
`FileNotFoundError: [Errno 2] No such file or directory .... default_config.yml`