### PR TITLE
修复 pip 10.0 安装时提示 'No module named pip.req' 的问题.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,21 +17,24 @@
 
 import sys
 from os.path import dirname, join
-from pip.req import parse_requirements
-
 from setuptools import (
     find_packages,
     setup,
 )
 
 
+def parse_requirements(filename):
+    lineiter = (line.strip() for line in open(filename))
+    return [line for line in lineiter if line and not line.startswith("#")]
+
+
 with open(join(dirname(__file__), 'rqalpha/VERSION.txt'), 'rb') as f:
     version = f.read().decode('ascii').strip()
 
-requirements = [str(ir.req) for ir in parse_requirements("requirements.txt", session=False)]
+requirements = parse_requirements("requirements.txt")
 
 if sys.version_info.major == 2:
-    requirements += [str(ir.req) for ir in parse_requirements("requirements-py2.txt", session=False)]
+    requirements += parse_requirements("requirements-py2.txt")
 
 setup(
     name='rqalpha',


### PR DESCRIPTION
修复 pip 10.0 安装时提示 'No module named pip.req' 的问题.

删除了原来低版本 pip.req.parse_requirements 的方法。
重写了一个 parse_requirements 函数。

基本保持原来不变，兼容更新版本的pip。
往合并