### PR TITLE
修改 tick 回测 Before trading 无法获取当天白天数据的问题

### DIFF
--- a/rqalpha/mod/rqalpha_mod_sys_simulation/simulation_event_source.py
+++ b/rqalpha/mod/rqalpha_mod_sys_simulation/simulation_event_source.py
@@ -150,25 +150,25 @@ class SimulationEventSource(AbstractEventSource):
                 while True:
                     for tick in data_proxy.get_merge_ticks(self._get_universe(), date, last_dt):
                         # find before trading time
+
+                        calendar_dt = tick.datetime
+
+                        if calendar_dt < dt_before_day_trading:
+                            trading_dt = calendar_dt.replace(year=date.year, month=date.month, day=date.day)
+                        else:
+                            trading_dt = calendar_dt
+
                         if last_tick is None:
                             last_tick = tick
-                            dt = tick.datetime
-                            before_trading_dt = dt - datetime.timedelta(minutes=30)
-                            yield Event(EVENT.BEFORE_TRADING, calendar_dt=before_trading_dt,
-                                        trading_dt=before_trading_dt)
+                            yield Event(EVENT.BEFORE_TRADING,
+                                        calendar_dt=calendar_dt - datetime.timedelta(minutes=30),
+                                        trading_dt=trading_dt - datetime.timedelta(minutes=30))
 
-                        dt = tick.datetime
-
-                        if dt < dt_before_day_trading:
-                            trading_dt = dt.replace(year=date.year, month=date.month, day=date.day)
-                        else:
-                            trading_dt = dt
-
-                        yield Event(EVENT.TICK, calendar_dt=dt, trading_dt=trading_dt, tick=tick)
+                        yield Event(EVENT.TICK, calendar_dt=calendar_dt, trading_dt=trading_dt, tick=tick)
 
                         if self._universe_changed:
                             self._universe_changed = False
-                            last_dt = dt
+                            last_dt = calendar_dt
                             break
                     else:
                         break


### PR DESCRIPTION
修改了 simulation_event_source 中 tick 回测部分。
原来如果运行期货 tick 回测，会在 20:30 夜盘前运行Before trading 的时候无法获取当天白天日线数据。