### PR TITLE
stock cash validator 中加入了对佣金的设置

### DIFF
--- a/rqalpha/mod/rqalpha_mod_sys_risk/cash_validator.py
+++ b/rqalpha/mod/rqalpha_mod_sys_risk/cash_validator.py
@@ -28,7 +28,10 @@ class CashValidator(AbstractFrontendValidator):
         if order.side == SIDE.SELL:
             return True
         # 检查可用资金是否充足
-        cost_money = order.frozen_price * order.quantity
+        # 保证占用资金包含了佣金部分, 在这里假定最小手续费就是5块, 佣金费率为万8。
+        # 没有区分不同柜台标准, 也没有根据回测中 mod_config 设置的佣金倍率进行改动, dirty hack
+        frozen_value = order.frozen_price * order.quantity
+        cost_money = frozen_value * 1.0008 if frozen_value * 0.0008 > 5 else frozen_value + 5
         if cost_money <= account.cash:
             return True
 


### PR DESCRIPTION
如果可用资金还有 1000，买入 100股，限价为10，那么由于 100*10+佣金 > 1000，此时会因可用资金不足而拒单