### PR TITLE
Fix Logger initialization time too long

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ line-profiler>=2.0
 PyYAML>=3.12
 
 tabulate
-colorama>=0.3.9

--- a/rqalpha/__main__.py
+++ b/rqalpha/__main__.py
@@ -201,27 +201,25 @@ def mod(cmd, params):
         """
         List all mod configuration
         """
-        from colorama import init, Fore
         from tabulate import tabulate
         from rqalpha.utils.config import get_mod_conf
-        init()
 
         mod_config = get_mod_conf()
         table = []
 
         for mod_name, mod in six.iteritems(mod_config['mod']):
             table.append([
-                Fore.RESET + mod_name,
-                (Fore.GREEN + "enabled" if mod['enabled'] else Fore.RED + "disabled") + Fore.RESET
+                mod_name,
+                ("enabled" if mod['enabled'] else "disabled")
             ])
 
         headers = [
-            Fore.CYAN + "name",
-            Fore.CYAN + "status" + Fore.RESET
+            "name",
+            "status"
         ]
 
         six.print_(tabulate(table, headers=headers, tablefmt="psql"))
-        six.print_(Fore.LIGHTYELLOW_EX + "You can use `rqalpha mod list/install/uninstall/enable/disable` to manage your mods")
+        six.print_("You can use `rqalpha mod list/install/uninstall/enable/disable` to manage your mods")
 
     def install(params):
         """

--- a/rqalpha/utils/logger.py
+++ b/rqalpha/utils/logger.py
@@ -16,8 +16,7 @@
 
 from datetime import datetime
 import logbook
-from logbook import Logger
-from logbook.more import ColorizedStderrHandler
+from logbook import Logger, StderrHandler
 
 from rqalpha.utils.py2 import to_utf8, from_utf8
 
@@ -52,7 +51,7 @@ def user_std_handler_log_formatter(record, handler):
     return log
 
 
-user_std_handler = ColorizedStderrHandler(bubble=True)
+user_std_handler = StderrHandler(bubble=True)
 user_std_handler.formatter = user_std_handler_log_formatter
 
 
@@ -80,7 +79,7 @@ user_system_log = Logger("user_system_log")
 
 # 用于用户异常的详细日志打印
 user_detail_log = Logger("user_detail_log")
-# user_detail_log.handlers.append(ColorizedStderrHandler(bubble=True))
+# user_detail_log.handlers.append(StderrHandler(bubble=True))
 
 # 系统日志
 system_log = Logger("system_log")
@@ -91,9 +90,9 @@ std_log = Logger("std_log")
 
 
 def init_logger():
-    system_log.handlers = [ColorizedStderrHandler(bubble=True)]
-    basic_system_log.handlers = [ColorizedStderrHandler(bubble=True)]
-    std_log.handlers = [ColorizedStderrHandler(bubble=True)]
+    system_log.handlers = [StderrHandler(bubble=True)]
+    basic_system_log.handlers = [StderrHandler(bubble=True)]
+    std_log.handlers = [StderrHandler(bubble=True)]
     user_log.handlers = []
     user_system_log.handlers = []
 


### PR DESCRIPTION
Multiple calls on ColorizedStderrHandler will get slower and slower , test.py can not be finish .
problem find in 'python test.py'
python = 3.6.3
Logbook = 1.4.1
colorama = 0.4.0
running in win10 cmd window