### PR TITLE
bugfix, persist encode-utf8 for booking while running with Realtime mode

### DIFF
--- a/rqalpha/model/booking.py
+++ b/rqalpha/model/booking.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import six
+import jsonpickle
 
 from rqalpha.environment import Environment
 from rqalpha.const import POSITION_DIRECTION, POSITION_EFFECT, SIDE
@@ -34,13 +35,14 @@ class BookingModel(object):
         self._backward_trade_set = set()
 
     def get_state(self):
-        return {
+        return jsonpickle.encode({
             "long_positions": self._positions_dict[POSITION_DIRECTION.LONG].get_state(),
             "short_positions": self._positions_dict[POSITION_DIRECTION.SHORT].get_state(),
             "backward_trade_set": list(self._backward_trade_set),
-        }
+        }).encode('utf-8')
 
     def set_state(self, state):
+        state = jsonpickle.decode(state.decode('utf-8'))
         if "long_positions" in state:
             self._positions_dict[POSITION_DIRECTION.LONG].set_state(state["long_positions"])
         if "short_positions" in state:

--- a/tests/unittest/test_model/test_booking.py
+++ b/tests/unittest/test_model/test_booking.py
@@ -1,4 +1,5 @@
 import datetime
+import jsonpickle
 
 from rqalpha.utils.testing import MagicMock, BookingFixture, RQAlphaTestCase
 from rqalpha.const import POSITION_DIRECTION, SIDE, POSITION_EFFECT
@@ -34,7 +35,7 @@ class BookingTestCase(BookingFixture, RQAlphaTestCase):
                 return delisted_ins
             return not_delisted_ins
 
-        self.booking.set_state({
+        self.booking.set_state(jsonpickle.encode({
             "long_positions": {
                 "RB1812": {
                     "old_quantity": 1, "today_quantity": 3
@@ -44,7 +45,7 @@ class BookingTestCase(BookingFixture, RQAlphaTestCase):
                     "today_quantity": 4
                 }
             }
-        })
+        }).encode('utf-8'))
 
         self.assertPositions({
             (POSITION_DIRECTION.LONG, "RB1812", 3, 1),


### PR DESCRIPTION
no such a issue under backtesting, only happens to realtime

``` bash
[2019-01-11 09:17:07.153870] ERROR: system_log: PersistHelper.persist fail
Traceback (most recent call last):
  File "/mnt/github/rqalpha/rqalpha/utils/persisit_helper.py", line 68, in persist
    md5 = hashlib.md5(state).hexdigest()
TypeError: object supporting the buffer API required
[2019-01-11 09:17:11.830196] DEBUG: system_log: real_dt 2019-01-11 09:17:07.154037, dt 2019-01-11 09:17:11.830038, event EVENT.BAR

```