### PR TITLE
Fix #429: resolve PY2 compatibility of FileNotFoundError

### DIFF
--- a/rqalpha/data/share_transformation_store.py
+++ b/rqalpha/data/share_transformation_store.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import json
+import six
 
 from rqalpha.utils.logger import system_log
 
@@ -56,6 +57,12 @@ DEFAULT_SHARE_TRANSFORMATION = {
     "event": "code_change"
   }
 }
+
+
+if six.PY2:
+    # FileNotFoundError is only available since Python 3.3
+    FileNotFoundError = IOError
+    from io import open
 
 
 class ShareTransformationStore(object):


### PR DESCRIPTION
## Purpose

- Bug fix.
- Resolve PY2 compatibility of `FileNotFoundError` and `open()` func.

## Problems

fix: #429 
related: #428 

