### PR TITLE
initialize ExecutionContext before env.set_portfolio

### DIFF
--- a/rqalpha/main.py
+++ b/rqalpha/main.py
@@ -124,6 +124,9 @@ def init_rqdatac(rqdatac_uri):
 
 
 def run(config, source_code=None, user_funcs=None):
+    ctx = ExecutionContext(const.EXECUTION_PHASE.GLOBAL)
+    ctx._push()
+
     env = Environment(config)
     persist_helper = None
     init_succeed = False
@@ -159,9 +162,6 @@ def run(config, source_code=None, user_funcs=None):
         if env.portfolio is None:
             from rqalpha.portfolio import Portfolio
             env.set_portfolio(Portfolio(config.base.accounts, config.base.init_positions))
-
-        ctx = ExecutionContext(const.EXECUTION_PHASE.GLOBAL)
-        ctx._push()
 
         env.event_bus.publish_event(Event(EVENT.POST_SYSTEM_INIT))
 


### PR DESCRIPTION
当前，ctx = ExecutionContext(const.EXECUTION_PHASE.GLOBAL) 处于 env.set_portfolio(Portfolio(config.base.accounts, config.base.init_position 后面，
实际上 ExecutionContext.phase() 此时的 stack 是空的。
会引起 ExecutionContext.phase() 空值异常。 
BarDictPriceBoard 
def _get_bar(self, order_book_id):
        if ExecutionContext.phase() == EXECUTION_PHASE.OPEN_AUCTION:
           ...
