### PR TITLE
Bugfix/Adding back "open_interest" futures' field

### DIFF
--- a/rqalpha/data/base_data_source/data_source.py
+++ b/rqalpha/data/base_data_source/data_source.py
@@ -16,30 +16,30 @@
 #         详细的授权流程，请联系 public@ricequant.com 获取。
 import os
 import pickle
-from itertools import groupby
 from datetime import date, datetime
-from typing import Dict, List, Union, Optional, Sequence, Iterable
+from itertools import groupby
+from typing import Dict, Iterable, List, Optional, Sequence, Union
 
-import six
 import numpy as np
 import pandas as pd
-
-from rqalpha.interface import AbstractDataSource
-from rqalpha.utils.functools import lru_cache
-from rqalpha.utils.datetime_func import convert_date_to_int, convert_int_to_date
+import six
 from rqalpha.const import INSTRUMENT_TYPE, TRADING_CALENDAR_TYPE
+from rqalpha.interface import AbstractDataSource
 from rqalpha.model.instrument import Instrument
+from rqalpha.utils.datetime_func import (convert_date_to_int,
+                                         convert_int_to_date)
 from rqalpha.utils.exception import RQInvalidArgument
+from rqalpha.utils.functools import lru_cache
 from rqalpha.utils.typing import DateLike
 
-from .storage_interface import (
-    AbstractInstrumentStore, AbstractCalendarStore, AbstractDayBarStore, AbstractDateSet, AbstractDividendStore
-)
-from .storages import (
-    InstrumentStore, ShareTransformationStore, FutureInfoStore, ExchangeTradingCalendarStore, DateSet, DayBarStore,
-    DividendStore, YieldCurveStore, SimpleFactorStore
-)
-from .adjust import adjust_bars, FIELDS_REQUIRE_ADJUSTMENT
+from .adjust import FIELDS_REQUIRE_ADJUSTMENT, adjust_bars
+from .storage_interface import (AbstractCalendarStore, AbstractDateSet,
+                                AbstractDayBarStore, AbstractDividendStore,
+                                AbstractInstrumentStore)
+from .storages import (DateSet, DayBarStore, DividendStore,
+                       ExchangeTradingCalendarStore, FutureInfoStore,
+                       InstrumentStore, ShareTransformationStore,
+                       SimpleFactorStore, YieldCurveStore)
 
 
 class BaseDataSource(AbstractDataSource):
@@ -170,7 +170,7 @@ class BaseDataSource(AbstractDataSource):
 
     @lru_cache(None)
     def _all_day_bars_of(self, instrument):
-        return self._day_bars[instrument.type].get_bars(instrument.order_book_id)
+        return self._day_bars[instrument.type].get_bars(instrument.order_book_id, instrument=instrument) 
 
     @lru_cache(None)
     def _filtered_day_bars(self, instrument):
@@ -256,8 +256,8 @@ class BaseDataSource(AbstractDataSource):
 
     def available_data_range(self, frequency):
         # FIXME
-        from rqalpha.environment import Environment
         from rqalpha.const import DEFAULT_ACCOUNT_TYPE
+        from rqalpha.environment import Environment
         accounts = Environment.get_instance().config.base.accounts
         if not (DEFAULT_ACCOUNT_TYPE.STOCK in accounts or DEFAULT_ACCOUNT_TYPE.FUTURE in accounts):
             return date.min, date.max

--- a/rqalpha/data/base_data_source/storages.py
+++ b/rqalpha/data/base_data_source/storages.py
@@ -15,30 +15,31 @@
 #         在此前提下，对本软件的使用同样需要遵守 Apache 2.0 许可，Apache 2.0 许可与本许可冲突之处，以本许可为准。
 #         详细的授权流程，请联系 public@ricequant.com 获取。
 
-import os
-import sys
-import locale
 import codecs
+import json
+import locale
+import os
+import pickle
+import sys
 from copy import copy
 from itertools import chain
-from typing import Optional, Iterable, Dict
+from typing import Dict, Iterable, Optional
 
-from rqalpha.data.base_data_source.storage_interface import AbstractSimpleFactorStore
-from rqalpha.utils.functools import lru_cache
-
-import json
 import h5py
-import pandas
 import numpy as np
-
-from rqalpha.utils.datetime_func import convert_date_to_date_int
-from rqalpha.utils.i18n import gettext as _
+import pandas
 from rqalpha.const import COMMISSION_TYPE, INSTRUMENT_TYPE
 from rqalpha.model.instrument import Instrument
+from rqalpha.utils.datetime_func import convert_date_to_date_int
+from rqalpha.utils.functools import lru_cache
+from rqalpha.utils.i18n import gettext as _
 
-from .storage_interface import AbstractCalendarStore, AbstractInstrumentStore, AbstractDayBarStore, AbstractDateSet
-from .storage_interface import AbstractDividendStore
+from .storage_interface import (AbstractCalendarStore, AbstractDateSet,
+                                AbstractDayBarStore, AbstractDividendStore,
+                                AbstractInstrumentStore,
+                                AbstractSimpleFactorStore)
 
+FUTURES_MISSING_FIELDS = ['open_interest', 'basis_spread']
 
 class ExchangeTradingCalendarStore(AbstractCalendarStore):
     def __init__(self, f):
@@ -167,11 +168,22 @@ class DayBarStore(AbstractDayBarStore):
             raise FileExistsError("File {} not exist，please update bundle.".format(path))
         self._h5 = open_h5(path, mode="r")
 
-    def get_bars(self, order_book_id):
+    def get_bars(self, order_book_id, instrument=None):
         try:
-            return self._h5[order_book_id][:]
+            bars = self._h5[order_book_id][:]
         except KeyError:
-            return np.empty(0, dtype=self.DEFAULT_DTYPE)
+            bars = np.empty(0, dtype=self.DEFAULT_DTYPE)
+        if instrument is not None and instrument.type == 'Future':
+            new_fields = [field for field in FUTURES_MISSING_FIELDS if field not in bars.dtype.names]
+            if new_fields:
+                new_dt = np.dtype(bars.dtype.descr + [(field, '<f8') for field in new_fields])
+                b = np.zeros(bars.shape, dtype=new_dt)
+                for name in bars.dtype.names:
+                    b[name] = bars[name]
+                for field in new_fields:
+                    b[field] = np.nan
+                bars = b
+        return bars
 
     def get_date_range(self, order_book_id):
         try:

--- a/rqalpha/data/base_data_source/storages.py
+++ b/rqalpha/data/base_data_source/storages.py
@@ -39,7 +39,7 @@ from .storage_interface import (AbstractCalendarStore, AbstractDateSet,
                                 AbstractInstrumentStore,
                                 AbstractSimpleFactorStore)
 
-FUTURES_MISSING_FIELDS = ['open_interest', 'basis_spread']
+FUTURES_MISSING_FIELDS = ['open_interest']
 
 class ExchangeTradingCalendarStore(AbstractCalendarStore):
     def __init__(self, f):

--- a/rqalpha/data/bundle.py
+++ b/rqalpha/data/bundle.py
@@ -316,36 +316,54 @@ class GenerateDayBarTask(DayBarTask):
 
 
 class UpdateDayBarTask(DayBarTask):
+    def h5_has_valid_fields(self, h5, wanted_fields):
+        obid_gen = (k for k in h5.keys())
+        wanted_fields = set(wanted_fields)
+        wanted_fields.add('datetime')
+        try:
+            h5_fields = set(h5[next(obid_gen)].dtype.fields.keys())
+        except StopIteration:
+            pass
+        else:
+            return h5_fields == wanted_fields
+        return False
+
     def __call__(self, path, fields, **kwargs):
-        with h5py.File(path, 'a') as h5:
-            for order_book_id in self._order_book_ids:
-                if order_book_id in h5:
-                    try:
-                        start_date = rqdatac.get_next_trading_date(int(h5[order_book_id]['datetime'][-1] // 1000000))
-                    except ValueError:
-                        h5.pop(order_book_id)
-                        start_date = START_DATE
-                else:
-                    start_date = START_DATE
-                df = rqdatac.get_price(order_book_id, start_date, END_DATE, '1d',
-                                       adjust_type='none', fields=fields, expect_df=True)
-                if not (df is None or df.empty):
-                    df = df[fields]  # Future order_book_id like SC888 will auto add 'dominant_id'
-                    df = df.loc[order_book_id]
-                    df.reset_index(inplace=True)
-                    df['datetime'] = [convert_date_to_int(d) for d in df['date']]
-                    del df['date']
-                    df.set_index('datetime', inplace=True)
+        need_recreate_h5 = False
+        with h5py.File(path, 'r') as h5:
+            need_recreate_h5 = not self.h5_has_valid_fields(h5, fields)
+        if need_recreate_h5:
+            return GenerateDayBarTask(self._order_book_ids)(path, fields, **kwargs)
+        else:
+            with h5py.File(path, 'a') as h5:
+                for order_book_id in self._order_book_ids:
                     if order_book_id in h5:
-                        data = np.array(
-                            [tuple(i) for i in chain(h5[order_book_id][:], df.to_records())],
-                            dtype=h5[order_book_id].dtype
-                        )
-                        del h5[order_book_id]
-                        h5.create_dataset(order_book_id, data=data, **kwargs)
+                        try:
+                            start_date = rqdatac.get_next_trading_date(int(h5[order_book_id]['datetime'][-1] // 1000000))
+                        except ValueError:
+                            h5.pop(order_book_id)
+                            start_date = START_DATE
                     else:
-                        h5.create_dataset(order_book_id, data=df.to_records(), **kwargs)
-                yield 1
+                        start_date = START_DATE
+                    df = rqdatac.get_price(order_book_id, start_date, END_DATE, '1d',
+                                        adjust_type='none', fields=fields, expect_df=True)
+                    if not (df is None or df.empty):
+                        df = df[fields]  # Future order_book_id like SC888 will auto add 'dominant_id'
+                        df = df.loc[order_book_id]
+                        df.reset_index(inplace=True)
+                        df['datetime'] = [convert_date_to_int(d) for d in df['date']]
+                        del df['date']
+                        df.set_index('datetime', inplace=True)
+                        if order_book_id in h5:
+                            data = np.array(
+                                [tuple(i) for i in chain(h5[order_book_id][:], df.to_records())],
+                                dtype=h5[order_book_id].dtype
+                            )
+                            del h5[order_book_id]
+                            h5.create_dataset(order_book_id, data=data, **kwargs)
+                        else:
+                            h5.create_dataset(order_book_id, data=df.to_records(), **kwargs)
+                    yield 1
 
 
 def init_rqdatac_with_warnings_catch():

--- a/rqalpha/data/bundle.py
+++ b/rqalpha/data/bundle.py
@@ -275,7 +275,7 @@ class GenerateFileTask(ProgressedTask):
 STOCK_FIELDS = ['open', 'close', 'high', 'low', 'limit_up', 'limit_down', 'volume', 'total_turnover']
 INDEX_FIELDS = ['open', 'close', 'high', 'low', 'volume', 'total_turnover']
 # FUTURES_FIELDS = STOCK_FIELDS + ['basis_spread', 'settlement', 'prev_settlement']
-FUTURES_FIELDS = STOCK_FIELDS + ['settlement', 'prev_settlement']
+FUTURES_FIELDS = STOCK_FIELDS + ['settlement', 'prev_settlement', 'open_interest']
 # FUND_FIELDS = STOCK_FIELDS + ['acc_net_value', 'unit_net_value', 'discount_rate']
 FUND_FIELDS = STOCK_FIELDS
 


### PR DESCRIPTION
This PR resolved an issue in the previous PR by removing a deprecated RQData futures field "basis_spread". Also, when executing DayBar updates, it would recreate the h5 file if it does not have wanted fields.