### PR TITLE
docs: fix simple typo, accout -> account

### DIFF
--- a/rqalpha/core/events.py
+++ b/rqalpha/core/events.py
@@ -143,7 +143,7 @@ class EVENT(Enum):
     ORDER_UNSOLICITED_UPDATE = 'order_unsolicited_update'
 
     # 成交
-    # trade(accout, trade, order)
+    # trade(account, trade, order)
     TRADE = 'trade'
 
     ON_LINE_PROFILER_RESULT = 'on_line_profiler_result'


### PR DESCRIPTION
There is a small typo in rqalpha/core/events.py.

Should read `account` rather than `accout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md