### PR TITLE
watch docs change should wait for finish

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -204,4 +204,4 @@ htmlview: html
 	 $(PYTHON) -c "import webbrowser; webbrowser.get('open -a /Applications/Google\ Chrome.app %s').open('build/html/index.html')"
 
 watch: htmlview
-	watchmedo shell-command -p '*.rst' -c 'make html' -R -D
+	watchmedo shell-command -p '*.rst' -c 'make html' -R -D --wait


### PR DESCRIPTION
`make watch` produces the following error:

```
Exception occurred:
  File "/home/xlc1/.local/share/virtualenvs/xlalpha-m-iXP8dt/lib/python3.8/site-packages/sphinx/builders/html/__init__.py", line 1106, in dump_search_index
    os.replace(searchindexfn + '.tmp', searchindexfn)
FileNotFoundError: [Errno 2] No such file or directory: '/home/xlc1/Desktop/programs/xlalpha/docs/build/html/searchindex.js.tmp' -> '/home/xlc1/Desktop/programs/xlalpha/docs/build/html/searchindex.js'
The full traceback has been saved in /tmp/sphinx-err-fxqrx805.log, if you want to report the issue to the developers.
```

It is likely due to two 'make html' command being executed by watchdog concurrently. Adding `--wait` flag should make one wait for the other to finish.