### PR TITLE
修正增量回测临界点异常状况

### DIFF
--- a/rqalpha/mod/rqalpha_mod_sys_analyser/mod.py
+++ b/rqalpha/mod/rqalpha_mod_sys_analyser/mod.py
@@ -143,6 +143,10 @@ class AnalyserMod(AbstractMod):
         date = self._env.calendar_dt.date()
         portfolio = self._env.portfolio
 
+        # 在进行增量回测时，起始记录点会是上一个阶段的结束日期，导致有重复的交易日期
+        if len(self._total_portfolios) > 0 and self._total_portfolios[-1]["date"] == date:
+            return
+
         self._portfolio_daily_returns.append(portfolio.daily_returns)
         self._total_portfolios.append(self._to_portfolio_record(date, portfolio))
         self._benchmark_daily_returns.append(self.get_benchmark_daily_returns())


### PR DESCRIPTION
RQSDK-482：增量回测时会在临界点出现重复的日期，增量部分会重复上一个区间的最后一个日期，同时后出现的重复日期的最新价不正确，它的取值是回测区间最开始的价格，所以曲线会出现跳变到0%，认为采用过滤的方式来处理掉可能会方便些。