### PR TITLE
Support log scale for the return curve.

### DIFF
--- a/rqalpha/mod/rqalpha_mod_sys_analyser/__init__.py
+++ b/rqalpha/mod/rqalpha_mod_sys_analyser/__init__.py
@@ -43,7 +43,9 @@ __config__ = {
         # 是否在收益图中展示买卖点
         'open_close_points': False,
         # 是否在收益图中展示周度指标和收益曲线
-        'weekly_indicators': False
+        'weekly_indicators': False,
+        # 是否对收益图使用对数坐标
+        'log_scale': False
     },
 }
 
@@ -95,6 +97,11 @@ inject_run_param(click.Option(
     is_flag=True, default=None,
     help=_("[sys_analyser] show weekly indicators and return curve on plot")
 ))
+inject_run_param(click.Option(
+    ("--plot-log-scale", cli_prefix + "plot_config__log_scale"),
+    is_flag=True, default=None,
+    help=_("[sys_analyser] show return curve at log scale")
+))
 
 
 @cli.command(help=_("[sys_analyser] Plot from strategy output file"))
@@ -103,13 +110,14 @@ inject_run_param(click.Option(
 @click.option('--plot-save', 'plot_save_file', default=None, type=click.Path(), help=_("save plot result to file"))
 @click.option('--plot-open-close-points', is_flag=True, help=_("show open close points on plot"))
 @click.option('--plot-weekly-indicators', is_flag=True, help=_("show weekly indicators and return curve on plot"))
-def plot(result_pickle_file_path, show, plot_save_file, plot_open_close_points, plot_weekly_indicators):
+@click.option('--plot-log-scale', is_flag=True, help=_("show return curve at log scale"))
+def plot(result_pickle_file_path, show, plot_save_file, plot_open_close_points, plot_weekly_indicators, plot_log_scale):
     import pandas as pd
     from .plot import plot_result
 
     result_dict = pd.read_pickle(result_pickle_file_path)
     print(plot_open_close_points, plot_weekly_indicators)
-    plot_result(result_dict, show, plot_save_file, plot_weekly_indicators, plot_open_close_points)
+    plot_result(result_dict, show, plot_save_file, plot_weekly_indicators, plot_open_close_points, plot_log_scale)
 
 
 @cli.command(help=_("[sys_analyser] Generate report from strategy output file"))

--- a/rqalpha/mod/rqalpha_mod_sys_analyser/mod.py
+++ b/rqalpha/mod/rqalpha_mod_sys_analyser/mod.py
@@ -570,7 +570,8 @@ class AnalyserMod(AbstractMod):
             _plot_template_cls = PLOT_TEMPLATE.get(self._mod_config.plot, DefaultPlot)
             plot_result(
                 result_dict, self._mod_config.plot, self._mod_config.plot_save_file,
-                plot_config.weekly_indicators, plot_config.open_close_points, _plot_template_cls, self._mod_config.strategy_name
+                plot_config.weekly_indicators, plot_config.open_close_points, _plot_template_cls, self._mod_config.strategy_name,
+                plot_config.log_scale
             )
 
         return result_dict


### PR DESCRIPTION
添加了对数轴收益率曲线的支持。

效果图：
<img width="905" alt="log_linear_compare_1" src="https://github.com/ricequant/rqalpha/assets/34575150/a5c2bf4e-6b92-4901-ae00-43110bcbad1d">

默认坐标回测后期的净值比较大，初期涨跌就不易观察；对数坐标使得观察更容易

Fixes #870