### PR TITLE
fix use symbol to get instrument error

### DIFF
--- a/rqalpha/data/base_data_source/data_source.py
+++ b/rqalpha/data/base_data_source/data_source.py
@@ -189,8 +189,9 @@ class BaseDataSource(AbstractDataSource):
         if id_or_syms is not None:
             seen = set()
             for i in id_or_syms:
-                if i in self._id_or_sym_instrument_map:
-                    for ins in self._id_or_sym_instrument_map.get(i, {}).values():
+                v = self._id_or_sym_instrument_map.get(i)
+                if v:
+                    for ins in v.values():
                         if ins not in seen:
                             seen.add(ins)
                             yield ins


### PR DESCRIPTION
defaultdict 和 ChainMap 共同使用时，会出现问题：
1. 两个 defaultdict A 和 B，ChainMap 后获得 C
2. 使用 C[key] 进行查找时，会先在 A 中查找，这是如果没有对应的 key 会直接返回 {}，然后就不去 B 中查找了，导致有时候查找数据会出现问题