### PR TITLE
order_target_portfolio_smart 支持 可转债、etf、lof、reits

### DIFF
--- a/rqalpha/mod/rqalpha_mod_sys_accounts/api/order_target_portfolio.py
+++ b/rqalpha/mod/rqalpha_mod_sys_accounts/api/order_target_portfolio.py
@@ -100,8 +100,15 @@ class OrderTargetPortfolio:
         self._env = env
 
         instruments = env.data_proxy.get_active_instruments(index, env.trading_dt)
+        supported_instrument_types = {
+            INSTRUMENT_TYPE.CS,
+            INSTRUMENT_TYPE.CONVERTIBLE,
+            INSTRUMENT_TYPE.ETF,
+            INSTRUMENT_TYPE.LOF,
+            INSTRUMENT_TYPE.REITs,
+        }
         for i in instruments.values():
-            if i.type != INSTRUMENT_TYPE.CS:
+            if i.type not in supported_instrument_types:
                 raise RQApiNotSupportedError(_('instrument type {} is not supported').format(i.type))
 
         self._market = Series({i.order_book_id: i.market for i in instruments.values()}, dtype='object')
@@ -303,6 +310,7 @@ class OrderTargetPortfolio:
             last_proportion_diff = proportion_diff
             safety -= min(max(proportion_diff / 10, 0.0001), 0.002)
         return AdjustingResult(adjustments=last_diff, denials=self._format_denials(last_denials))
+
 
 @export_as_api
 @ExecutionContext.enforce_phase(

--- a/rqalpha/mod/rqalpha_mod_sys_accounts/api/order_target_portfolio.py
+++ b/rqalpha/mod/rqalpha_mod_sys_accounts/api/order_target_portfolio.py
@@ -72,6 +72,15 @@ class DenialReason(CommentedEnum):
     closable_exceeded = 'closable_exceeded', lazy_gettext('Order creation failed: insufficient closable position')
 
 
+SUPPORTED_INSTRUMENT_TYPES = {
+    INSTRUMENT_TYPE.CS,
+    INSTRUMENT_TYPE.CONVERTIBLE,
+    INSTRUMENT_TYPE.ETF,
+    INSTRUMENT_TYPE.LOF,
+    INSTRUMENT_TYPE.REITs,
+}
+
+
 class OrderTargetPortfolio:
     def __init__(
         self,
@@ -100,15 +109,8 @@ class OrderTargetPortfolio:
         self._env = env
 
         instruments = env.data_proxy.get_active_instruments(index, env.trading_dt)
-        supported_instrument_types = {
-            INSTRUMENT_TYPE.CS,
-            INSTRUMENT_TYPE.CONVERTIBLE,
-            INSTRUMENT_TYPE.ETF,
-            INSTRUMENT_TYPE.LOF,
-            INSTRUMENT_TYPE.REITs,
-        }
         for i in instruments.values():
-            if i.type not in supported_instrument_types:
+            if i.type not in SUPPORTED_INSTRUMENT_TYPES:
                 raise RQApiNotSupportedError(_('instrument type {} is not supported').format(i.type))
 
         self._market = Series({i.order_book_id: i.market for i in instruments.values()}, dtype='object')

--- a/rqalpha/model/instrument.py
+++ b/rqalpha/model/instrument.py
@@ -397,8 +397,10 @@ class Instrument(metaclass=PropertyReprMeta):
     @cached_property
     def order_step_size(self):
         # 下单递进股数
-        if self.board_type == "KSH" or self.board_type == "BJS":
-            return 1
+        if self.type == INSTRUMENT_TYPE.CS:
+            # 对于其他资产类型 instrument 中（如可转债）可能没有 board_type 字段
+            if self.board_type == "KSH" or self.board_type == "BJS":
+                return 1
         return self.round_lot
 
     def during_call_auction(self, dt):
@@ -445,7 +447,7 @@ class Instrument(metaclass=PropertyReprMeta):
         # type: () -> float
         if self.type in (INSTRUMENT_TYPE.CS, INSTRUMENT_TYPE.INDX):
             return 0.01
-        elif self.type in ("ETF", "LOF"):
+        elif self.type in ("ETF", "LOF", "REITs"):
             return 0.001
         elif self.type == INSTRUMENT_TYPE.FUTURE:
             return self._futures_tick_size_getter(self)


### PR DESCRIPTION
extra:
1. instruments board_type 适配可转债
2. 滑点跳数支持reits