### PR TITLE
Add optional Adanos sentiment mod

### DIFF
--- a/docs/source/development/data_source.rst
+++ b/docs/source/development/data_source.rst
@@ -253,6 +253,43 @@ RQAlpha 不限制本地运行的策略调使用哪些库，因此您可以直接
 
 至此，我们就可以直接在策略中使用 `get_csv_as_df` 函数了。
 
+Adanos 市场情绪扩展 API
+------------------------------------
+
+RQAlpha 内置了可选的 Adanos Market Sentiment API Mod，可用于查询 Reddit、X、News 和 Polymarket 的美股市场情绪信号。
+该 Mod 默认不会启用，只有在策略配置中显式开启后才会注入对应的扩展 API。
+
+..  code-block:: python3
+
+    from rqalpha.api import *
+
+
+    def handle_bar(context, bar_dict):
+        sentiment = adanos_sentiment("TSLA.US", source="reddit", days=7)
+        if sentiment["sentiment_score"] > 0:
+            logger.info(sentiment)
+
+
+    __config__ = {
+        "mod": {
+            "adanos_sentiment": {
+                "enabled": True,
+                "lib": "rqalpha.mod.rqalpha_mod_adanos_sentiment",
+                "api_key": "your-api-key",
+                "source": "reddit",
+            }
+        }
+    }
+
+API Key 也可以通过 ``ADANOS_API_KEY`` 环境变量提供。
+
+该 Mod 提供两个策略 API：
+
+*   :code:`adanos_sentiment(order_book_id, source=None, days=7)`: 查询单个美股。``order_book_id`` 可以是 ``"TSLA"`` 或 ``"TSLA.US"``。
+*   :code:`adanos_sentiment_compare(order_book_ids, source=None, days=7)`: 查询多个美股的情绪对比。``order_book_ids`` 可以是逗号分隔字符串或可迭代对象。
+
+支持的数据源为 ``reddit``, ``x``, ``news`` 和 ``polymarket``。
+
 替换已有数据源
 ====================================
 

--- a/rqalpha/mod/rqalpha_mod_adanos_sentiment/README.rst
+++ b/rqalpha/mod/rqalpha_mod_adanos_sentiment/README.rst
@@ -1,0 +1,53 @@
+===============================
+adanos_sentiment Mod
+===============================
+
+该 Mod 为策略提供可选的 Adanos Market Sentiment API 查询能力，支持 Reddit、X、News 和 Polymarket 的美股市场情绪数据。
+
+模块配置项
+===============================
+
+..  code-block:: python
+
+    {
+        "api_key": "",  # 也可以设置 ADANOS_API_KEY 环境变量
+        "base_url": "https://api.adanos.org",
+        "source": "reddit",
+        "timeout": 10,
+    }
+
+使用方式
+===============================
+
+..  code-block:: python
+
+    from rqalpha.api import *
+
+
+    def handle_bar(context, bar_dict):
+        sentiment = adanos_sentiment("TSLA.US", source="reddit", days=7)
+        if sentiment["sentiment_score"] > 0:
+            logger.info(sentiment)
+
+
+    __config__ = {
+        "mod": {
+            "adanos_sentiment": {
+                "enabled": True,
+                "lib": "rqalpha.mod.rqalpha_mod_adanos_sentiment",
+                "api_key": "your-api-key",
+                "source": "reddit",
+            }
+        }
+    }
+
+API
+===============================
+
+``adanos_sentiment(order_book_id, source=None, days=7)``
+    查询单个美股的市场情绪数据。``order_book_id`` 可以是 ``"TSLA"`` 或 ``"TSLA.US"``。
+
+``adanos_sentiment_compare(order_book_ids, source=None, days=7)``
+    查询多个美股的市场情绪对比数据。``order_book_ids`` 可以是逗号分隔字符串或可迭代对象。
+
+支持的数据源: ``reddit``, ``x``, ``news``, ``polymarket``。

--- a/rqalpha/mod/rqalpha_mod_adanos_sentiment/__init__.py
+++ b/rqalpha/mod/rqalpha_mod_adanos_sentiment/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+__config__ = {
+    "api_key": "",
+    "base_url": "https://api.adanos.org",
+    "source": "reddit",
+    "timeout": 10,
+}
+
+
+def load_mod():
+    from .mod import AdanosSentimentMod
+
+    return AdanosSentimentMod()

--- a/rqalpha/mod/rqalpha_mod_adanos_sentiment/mod.py
+++ b/rqalpha/mod/rqalpha_mod_adanos_sentiment/mod.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+import os
+from collections.abc import Iterable
+
+import requests
+
+from rqalpha.const import EXECUTION_PHASE
+from rqalpha.core.execution_context import ExecutionContext
+from rqalpha.interface import AbstractMod
+
+
+ADANOS_SOURCES = {"reddit", "x", "news", "polymarket"}
+
+
+class AdanosSentimentMod(AbstractMod):
+    def __init__(self):
+        self._api_key = ""
+        self._base_url = "https://api.adanos.org"
+        self._source = "reddit"
+        self._timeout = 10
+        self._inject_api()
+
+    def start_up(self, env, mod_config):
+        self._api_key = (mod_config.api_key or os.getenv("ADANOS_API_KEY", "")).strip()
+        self._base_url = mod_config.base_url.rstrip("/")
+        self._source = self._normalize_source(mod_config.source)
+        self._timeout = mod_config.timeout
+
+    def tear_down(self, code, exception=None):
+        pass
+
+    def get_sentiment(self, order_book_id, source=None, days=7):
+        source = self._normalize_source(source or self._source)
+        ticker = self._normalize_order_book_id(order_book_id)
+        return self._request_json(
+            path="/{}/stocks/v1/stock/{}".format(source, ticker),
+            params={"days": days},
+        )
+
+    def compare_sentiment(self, order_book_ids, source=None, days=7):
+        source = self._normalize_source(source or self._source)
+        tickers = ",".join(
+            self._normalize_order_book_id(order_book_id)
+            for order_book_id in self._as_order_book_id_list(order_book_ids)
+        )
+        if not tickers:
+            raise ValueError("order_book_ids must contain at least one symbol")
+        return self._request_json(
+            path="/{}/stocks/v1/compare".format(source),
+            params={"tickers": tickers, "days": days},
+        )
+
+    def _inject_api(self):
+        from rqalpha.api import export_as_api
+
+        @export_as_api
+        @ExecutionContext.enforce_phase(
+            EXECUTION_PHASE.ON_INIT,
+            EXECUTION_PHASE.BEFORE_TRADING,
+            EXECUTION_PHASE.ON_BAR,
+            EXECUTION_PHASE.ON_TICK,
+            EXECUTION_PHASE.AFTER_TRADING,
+            EXECUTION_PHASE.SCHEDULED,
+        )
+        def adanos_sentiment(order_book_id, source=None, days=7):
+            return self.get_sentiment(order_book_id, source=source, days=days)
+
+        @export_as_api
+        @ExecutionContext.enforce_phase(
+            EXECUTION_PHASE.ON_INIT,
+            EXECUTION_PHASE.BEFORE_TRADING,
+            EXECUTION_PHASE.ON_BAR,
+            EXECUTION_PHASE.ON_TICK,
+            EXECUTION_PHASE.AFTER_TRADING,
+            EXECUTION_PHASE.SCHEDULED,
+        )
+        def adanos_sentiment_compare(order_book_ids, source=None, days=7):
+            return self.compare_sentiment(order_book_ids, source=source, days=days)
+
+    def _request_json(self, path, params):
+        api_key = self._api_key
+        if not api_key:
+            raise ValueError("Please set mod.api_key or ADANOS_API_KEY")
+
+        response = requests.get(
+            "{}{}".format(self._base_url, path),
+            params=params,
+            headers={"X-API-Key": api_key, "Accept": "application/json"},
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _normalize_source(source):
+        source = source.strip().lower()
+        if source not in ADANOS_SOURCES:
+            raise ValueError("source must be one of: reddit, x, news, polymarket")
+        return source
+
+    @staticmethod
+    def _normalize_order_book_id(order_book_id):
+        symbol = str(order_book_id).strip().split(".", 1)[0].upper()
+        if not symbol:
+            raise ValueError("order_book_id must not be empty")
+        return symbol
+
+    @staticmethod
+    def _as_order_book_id_list(order_book_ids):
+        if isinstance(order_book_ids, str):
+            return [item.strip() for item in order_book_ids.split(",") if item.strip()]
+        if isinstance(order_book_ids, Iterable):
+            return list(order_book_ids)
+        raise TypeError("order_book_ids must be a string or iterable")

--- a/tests/test_adanos_sentiment_mod.py
+++ b/tests/test_adanos_sentiment_mod.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from rqalpha.const import EXECUTION_PHASE
+from rqalpha.core.execution_context import ExecutionContext
+from rqalpha.mod.rqalpha_mod_adanos_sentiment import load_mod
+
+
+def _mod_config(**kwargs):
+    config = {
+        "api_key": "test-key",
+        "base_url": "https://api.adanos.org",
+        "source": "reddit",
+        "timeout": 10,
+    }
+    config.update(kwargs)
+    return SimpleNamespace(**config)
+
+
+def _mock_response(payload):
+    response = Mock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_adanos_sentiment_requests_single_stock():
+    mod = load_mod()
+    mod.start_up(None, _mod_config(source=" Reddit ", base_url="https://api.adanos.org/"))
+
+    with patch(
+        "rqalpha.mod.rqalpha_mod_adanos_sentiment.mod.requests.get",
+        return_value=_mock_response({"ticker": "TSLA", "sentiment_score": 0.25}),
+    ) as mock_get:
+        result = mod.get_sentiment(" tsla.us ", days=3)
+
+    assert result["ticker"] == "TSLA"
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.adanos.org/reddit/stocks/v1/stock/TSLA"
+    assert kwargs["params"] == {"days": 3}
+    assert kwargs["headers"]["X-API-Key"] == "test-key"
+    assert kwargs["headers"]["Accept"] == "application/json"
+    assert kwargs["timeout"] == 10
+
+
+def test_adanos_sentiment_compare_accepts_iterables():
+    mod = load_mod()
+    mod.start_up(None, _mod_config(source="news"))
+
+    with patch(
+        "rqalpha.mod.rqalpha_mod_adanos_sentiment.mod.requests.get",
+        return_value=_mock_response({"stocks": [{"ticker": "TSLA"}, {"ticker": "NVDA"}]}),
+    ) as mock_get:
+        result = mod.compare_sentiment(["TSLA.US", " nvda "], days=5)
+
+    assert [item["ticker"] for item in result["stocks"]] == ["TSLA", "NVDA"]
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.adanos.org/news/stocks/v1/compare"
+    assert kwargs["params"] == {"tickers": "TSLA,NVDA", "days": 5}
+
+
+def test_adanos_sentiment_compare_accepts_comma_separated_string():
+    mod = load_mod()
+    mod.start_up(None, _mod_config(source="polymarket"))
+
+    with patch(
+        "rqalpha.mod.rqalpha_mod_adanos_sentiment.mod.requests.get",
+        return_value=_mock_response({"stocks": []}),
+    ) as mock_get:
+        mod.compare_sentiment("tsla.us, nvda", days=7)
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"tickers": "TSLA,NVDA", "days": 7}
+
+
+def test_adanos_sentiment_uses_environment_api_key(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "env-key")
+    mod = load_mod()
+    mod.start_up(None, _mod_config(api_key=""))
+
+    with patch(
+        "rqalpha.mod.rqalpha_mod_adanos_sentiment.mod.requests.get",
+        return_value=_mock_response({"ticker": "AAPL"}),
+    ) as mock_get:
+        mod.get_sentiment("AAPL")
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["headers"]["X-API-Key"] == "env-key"
+
+
+def test_adanos_sentiment_requires_api_key(monkeypatch):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+    mod = load_mod()
+    mod.start_up(None, _mod_config(api_key=""))
+
+    with pytest.raises(ValueError, match="Please set mod.api_key"):
+        mod.get_sentiment("AAPL")
+
+
+def test_adanos_sentiment_validates_source_and_symbol():
+    mod = load_mod()
+
+    with pytest.raises(ValueError, match="source must be one of"):
+        mod.start_up(None, _mod_config(source="invalid"))
+
+    mod.start_up(None, _mod_config())
+    with pytest.raises(ValueError, match="order_book_id must not be empty"):
+        mod.get_sentiment(" ")
+
+
+def test_adanos_sentiment_exports_strategy_api():
+    mod = load_mod()
+    mod.start_up(None, _mod_config())
+
+    from rqalpha.api import adanos_sentiment
+
+    with patch.object(
+        mod,
+        "get_sentiment",
+        return_value={"ticker": "TSLA"},
+    ) as mock_get_sentiment:
+        with ExecutionContext(EXECUTION_PHASE.ON_BAR):
+            result = adanos_sentiment("TSLA.US", source="x", days=2)
+
+    assert result == {"ticker": "TSLA"}
+    mock_get_sentiment.assert_called_once_with("TSLA.US", source="x", days=2)
+
+
+def test_adanos_sentiment_compare_exports_strategy_api():
+    mod = load_mod()
+    mod.start_up(None, _mod_config())
+
+    from rqalpha.api import adanos_sentiment_compare
+
+    with patch.object(
+        mod,
+        "compare_sentiment",
+        return_value={"stocks": [{"ticker": "TSLA"}]},
+    ) as mock_compare_sentiment:
+        with ExecutionContext(EXECUTION_PHASE.ON_BAR):
+            result = adanos_sentiment_compare(["TSLA.US"], source="news", days=4)
+
+    assert result == {"stocks": [{"ticker": "TSLA"}]}
+    mock_compare_sentiment.assert_called_once_with(["TSLA.US"], source="news", days=4)


### PR DESCRIPTION
## Summary
- add an optional `adanos_sentiment` RQAlpha mod
- expose `adanos_sentiment` and `adanos_sentiment_compare` strategy APIs
- support API keys through mod config or `ADANOS_API_KEY`
- document usage in the data-source extension guide and the mod README
- add mocked tests for request mapping, validation, environment API keys, base URL normalization, and API exports

## Validation
- `.venv/bin/python -m pytest tests/test_adanos_sentiment_mod.py -q`
- `.venv/bin/python -m py_compile rqalpha/mod/rqalpha_mod_adanos_sentiment/__init__.py rqalpha/mod/rqalpha_mod_adanos_sentiment/mod.py tests/test_adanos_sentiment_mod.py`
- `git diff --check`
