### PR TITLE
fix(analyser): 兼容自定义数据源返回 DataFrame 的 benchmark 行情

### DIFF
--- a/rqalpha/mod/rqalpha_mod_sys_analyser/mod.py
+++ b/rqalpha/mod/rqalpha_mod_sys_analyser/mod.py
@@ -195,14 +195,17 @@ class AnalyserMod(AbstractMod):
                 _("benchmark {} missing data between backtest start date {} and end date {}").format(
                     ins.order_book_id, returns_s, e)
             )
+        # 本地 bundle 数据源返回 numpy structured array，自定义数据源（如 xtdata）可能返回
+        # pandas DataFrame；统一转换为 DataFrame，保证后续行列访问方式一致
+        bars = pd.DataFrame(bars)
         left = bars['datetime'].searchsorted(np.uint64(convert_date_to_int(bars_s)), side='left')
-        bars = bars[left:]
+        bars = bars.iloc[left:]
         try:
             calendar_type = self.NON_CN_CALENDAR_OIDS[ins.order_book_id]
         except KeyError:
             # A 股交易日历的标的，验证其价格的完整性
             if len(bars) == len(trading_dates):
-                if convert_int_to_date(bars[1]['datetime']) != returns_s:
+                if convert_int_to_date(bars['datetime'].iloc[1]) != returns_s:
                     raise RuntimeError(_(
                         "benchmark {} missing data between backtest start date {} and end date {}").format(ins.order_book_id, returns_s, e)
                     )
@@ -211,7 +214,10 @@ class AnalyserMod(AbstractMod):
                 if len(bars) == 0:
                     (available_s, available_e) = (ins.listed_date, ins.de_listed_date)
                 else:
-                    (available_s, available_e) = (convert_int_to_date(bars[0]['datetime']).date(), convert_int_to_date(bars[-1]['datetime']).date())
+                    (available_s, available_e) = (
+                        convert_int_to_date(bars['datetime'].iloc[0]).date(),
+                        convert_int_to_date(bars['datetime'].iloc[-1]).date(),
+                    )
                 raise RuntimeError(
                     _("benchmark {} available data start date {} >= backtest start date {} or end date {} <= backtest end "
                     "date {}").format(ins.order_book_id, available_s, returns_s, available_e, e)

--- a/tests/unittest/test_mod/test_sys_analyser.py
+++ b/tests/unittest/test_mod/test_sys_analyser.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+from rqalpha.mod.rqalpha_mod_sys_analyser.mod import AnalyserMod
+from rqalpha.utils.datetime_func import convert_date_to_int
+
+
+def make_trading_dates() -> pd.DatetimeIndex:
+    return pd.DatetimeIndex(
+        ["2025-03-03", "2025-03-04", "2025-03-05", "2025-03-06"]
+    )
+
+
+def make_instrument() -> SimpleNamespace:
+    return SimpleNamespace(order_book_id="000300.XSHG")
+
+
+def make_analyser(bars) -> AnalyserMod:
+    class FakeDataProxy:
+        def history_bars(self, **kwargs):
+            return bars
+
+    analyser = AnalyserMod()
+    analyser._env = SimpleNamespace(data_proxy=FakeDataProxy())
+    return analyser
+
+
+def make_bars(trading_dates: pd.DatetimeIndex, closes: list[float]) -> pd.DataFrame:
+    datetimes = np.array(
+        [np.uint64(convert_date_to_int(day.date())) for day in trading_dates],
+        dtype=np.uint64,
+    )
+    return pd.DataFrame({"datetime": datetimes, "close": closes})
+
+
+def expected_returns(closes: list[float]) -> np.ndarray:
+    close_series = pd.Series(closes)
+    return (close_series / close_series.shift(1) - 1.0).dropna().to_numpy()
+
+
+def test_benchmark_returns_with_dataframe_source() -> None:
+    trading_dates = make_trading_dates()
+    closes = [100.0, 101.0, 99.0, 102.0]
+    analyser = make_analyser(make_bars(trading_dates, closes))
+
+    returns = analyser._get_one_benchmark_daily_returns(
+        make_instrument(), trading_dates
+    )
+
+    np.testing.assert_allclose(returns, expected_returns(closes))
+
+
+def test_benchmark_returns_with_numpy_records_source() -> None:
+    trading_dates = make_trading_dates()
+    closes = [100.0, 101.0, 99.0, 102.0]
+    bars = make_bars(trading_dates, closes).to_records(index=False)
+    analyser = make_analyser(bars)
+
+    returns = analyser._get_one_benchmark_daily_returns(
+        make_instrument(), trading_dates
+    )
+
+    np.testing.assert_allclose(returns, expected_returns(closes))


### PR DESCRIPTION
Fixes #917

## 问题

本地自定义数据源（如 xtdata）的 `history_bars` 返回 pandas DataFrame，而内置 bundle 数据源返回 numpy structured array。`_get_one_benchmark_daily_returns` 中 `bars[1]['datetime']` 的行访问方式对 DataFrame 会触发 `KeyError: 1`（DataFrame 的 `bars[1]` 是取列），导致配置 benchmark 后回测直接报错。

## 修改

- 将 `history_bars` 结果统一转换为 pandas DataFrame，统一使用 `bars['datetime'].iloc[...]` 访问行，兼容 numpy structured array 与 pandas DataFrame 两类数据源
- 切片改为 `bars.iloc[left:]`，避免依赖 DataFrame 的标签索引
- 新增单元测试，覆盖 DataFrame 与 numpy records 两种数据源

## 验证

- `pytest tests/unittest/test_mod/test_sys_analyser.py`：2 个测试全部通过
- `pytest tests/unittest`：除缺少本地 bundle 数据及环境 i18n 差异导致的既有失败外，无新增失败