### PR TITLE
修复期货 order_to 返回嵌套空结果

### DIFF
--- a/rqalpha/mod/rqalpha_mod_sys_accounts/api/api_future.py
+++ b/rqalpha/mod/rqalpha_mod_sys_accounts/api/api_future.py
@@ -131,6 +131,15 @@ def _submit_order(order_book_id: str, amount, side, position_effect, style) -> U
         return orders
 
 
+def _append_order(orders: List[Order], order: Union[Order, List[Order], None]) -> None:
+    if order is None:
+        return
+    if isinstance(order, list):
+        orders.extend(order)
+    else:
+        orders.append(order)
+
+
 def _order(order_book_id: str, quantity: Union[int, float], style: OrderStyle, target: bool) -> List[Order]:
     portfolio = Environment.get_instance().portfolio
     long_position = portfolio.get_position(order_book_id, POSITION_DIRECTION.LONG)
@@ -138,6 +147,8 @@ def _order(order_book_id: str, quantity: Union[int, float], style: OrderStyle, t
     if target:
         # For order_to
         quantity -= (long_position.quantity - short_position.quantity)
+        if quantity == 0:
+            return []
     orders = []
 
     if quantity > 0:
@@ -153,20 +164,26 @@ def _order(order_book_id: str, quantity: Union[int, float], style: OrderStyle, t
     old_to_be_closed, today_to_be_closed = position_to_be_closed.old_quantity, position_to_be_closed.today_quantity
     if old_to_be_closed > 0:
         # 平昨仓
-        orders.append(_submit_order(order_book_id, min(quantity, old_to_be_closed), side, POSITION_EFFECT.CLOSE, style))
+        _append_order(
+            orders,
+            _submit_order(order_book_id, min(quantity, old_to_be_closed), side, POSITION_EFFECT.CLOSE, style),
+        )
         quantity -= old_to_be_closed
     if quantity <= 0:
         return orders
     if today_to_be_closed > 0:
         # 平今仓
-        orders.append(_submit_order(
-            order_book_id, min(quantity, today_to_be_closed), side, POSITION_EFFECT.CLOSE_TODAY, style
-        ))
+        _append_order(
+            orders,
+            _submit_order(
+                order_book_id, min(quantity, today_to_be_closed), side, POSITION_EFFECT.CLOSE_TODAY, style
+            ),
+        )
         quantity -= today_to_be_closed
     if quantity <= 0:
         return orders
     # 开仓
-    orders.append(_submit_order(order_book_id, quantity, side, POSITION_EFFECT.OPEN, style))
+    _append_order(orders, _submit_order(order_book_id, quantity, side, POSITION_EFFECT.OPEN, style))
     return orders
 
 

--- a/tests/integration_tests/test_api/test_api_future.py
+++ b/tests/integration_tests/test_api/test_api_future.py
@@ -121,6 +121,7 @@ def test_future_order_to():
             order_to(context.f1, 2)
             assert get_position(context.f1).quantity == 2
         elif context.counter == 2:
+            assert order_to(context.f1, 2) == []
             order_to(context.f1, -2)
             assert get_position(context.f1, POSITION_DIRECTION.SHORT).quantity == 2
             order_to(context.f1, 1)

--- a/tests/unittest/test_mod/test_sys_accounts/test_api/test_api_future.py
+++ b/tests/unittest/test_mod/test_sys_accounts/test_api/test_api_future.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from rqalpha.const import POSITION_DIRECTION, POSITION_EFFECT, SIDE
+from rqalpha.environment import Environment
+from rqalpha.mod.rqalpha_mod_sys_accounts.api.api_future import _order, _submit_order
+
+
+def _environment_with_positions(long_position, short_position):
+    positions = {
+        POSITION_DIRECTION.LONG: long_position,
+        POSITION_DIRECTION.SHORT: short_position,
+    }
+    portfolio = SimpleNamespace(
+        get_position=lambda _id, direction: positions[direction]
+    )
+    return SimpleNamespace(portfolio=portfolio, order_creation_failed=Mock())
+
+
+def test_submit_order_zero_quantity_returns_none():
+    env = SimpleNamespace(order_creation_failed=Mock())
+
+    with patch.object(Environment, "get_instance", return_value=env):
+        result = _submit_order("IF88", 0, SIDE.BUY, POSITION_EFFECT.OPEN, None)
+
+    assert result is None
+    env.order_creation_failed.assert_called_once()
+
+
+def test_order_to_same_target_returns_empty_without_order():
+    env = _environment_with_positions(
+        SimpleNamespace(quantity=1, old_quantity=1, today_quantity=0),
+        SimpleNamespace(quantity=0, old_quantity=0, today_quantity=0),
+    )
+
+    with patch.object(Environment, "get_instance", return_value=env):
+        result = _order("IF88", 1, None, target=True)
+
+    assert result == []
+    env.order_creation_failed.assert_not_called()
+
+
+@pytest.mark.parametrize("submission_result", [None, []])
+def test_order_drops_empty_submission_result(submission_result):
+    env = _environment_with_positions(
+        SimpleNamespace(quantity=0, old_quantity=0, today_quantity=0),
+        SimpleNamespace(quantity=0, old_quantity=0, today_quantity=0),
+    )
+
+    with patch.object(Environment, "get_instance", return_value=env), patch(
+        "rqalpha.mod.rqalpha_mod_sys_accounts.api.api_future._submit_order",
+        return_value=submission_result,
+    ):
+        result = _order("IF88", 1, None, target=False)
+
+    assert result == []


### PR DESCRIPTION
## 问题

期货 `order_to` 在已经达到目标仓位时仍会尝试创建零数量订单，返回 `[None]`；其他订单创建失败还可能被包装成 `[[]]`。这些结果与该 API 的 `List[Order]` 返回约定不一致。

## 修复

- 目标仓位没有变化时直接返回空列表，不再触发零数量订单失败事件
- 统一展开或忽略 `_submit_order` 返回的订单、空列表和 `None`
- 增加单元测试，并在现有期货集成场景中补充回归断言

Fixes #754.

## 测试

- 相关单元测试：4 passed
- 新增测试文件格式检查、`compileall` 和 `git diff --check`：通过
- 完整集成测试需要本地 RQAlpha bundle；新增的集成断言将由 CI 覆盖
